### PR TITLE
Add draft of generation of sliding puzzle configuration

### DIFF
--- a/common/sliding_puzzle/puzzle_base.gd
+++ b/common/sliding_puzzle/puzzle_base.gd
@@ -4,13 +4,13 @@ extends CanvasLayer
 signal solved
 signal exited
 
-
+const AXIS = BaseTile.AxisType
 var _puzzle_board = preload("res://common/sliding_puzzle/puzzle_board.tscn")
 var _cursor_scene = preload("res://common/sliding_puzzle/hand_cursor/hand_cursor.tscn")
 var _tile_dict = {
-	"v2": preload("res://common/sliding_puzzle/tiles/vertical_tile/vertical_tile.tscn"),
-	"h2": preload("res://common/sliding_puzzle/tiles/horizontal_tile/horizontal_tile.tscn"),
-	"m": preload("res://common/sliding_puzzle/tiles/main_tile/main_tile.tscn"),
+	AXIS.X: preload("res://common/sliding_puzzle/tiles/horizontal_tile/horizontal_tile.tscn"),
+	AXIS.Y: preload("res://common/sliding_puzzle/tiles/vertical_tile/vertical_tile.tscn"),
+	AXIS.M: preload("res://common/sliding_puzzle/tiles/main_tile/main_tile.tscn"),
 }
 var _screen_center
 
@@ -42,18 +42,26 @@ func _inst_at_middle(scene):
 
 func _inst_all_tiles():
 	for i in tile_location:
-		for j in tile_location[i]:
-			_inst_tile(j[0], j[1], _tile_dict[i])
+		for pos in tile_location[i]:
+			#_inst_tile(pos[0], pos[1], _tile_dict[i])
+			_inst_tile(pos, _tile_dict[i])
 
-func _inst_tile(x, y, tile):
+#func _inst_tile(x, y, tile):
+func _inst_tile(p: Vector2i, tile: Resource) -> void:
 	var child = tile.instantiate()
 	match child.axis:
 		BaseTile.AxisType.X:
-			child.global_position = _screen_center + Vector2(x * 60 - 30, -y * 60)
+			#child.global_position = _screen_center + Vector2(x * 60, -y * 60 + 30)
+			child.global_position = _screen_center\
+									+ Vector2(60 * (p.x - 2), 30 - 60 * (3 - p.y))
 		BaseTile.AxisType.Y:
-			child.global_position = _screen_center + Vector2(x * 60, -y * 60 + 30)
+			#child.global_position = _screen_center + Vector2(x * 60 - 30, -y * 60 + 60)
+			child.global_position = _screen_center\
+									+ Vector2(60 * (p.x - 2) - 30, 60 - 60 * (3 - p.y))
 		BaseTile.AxisType.M:
-			child.global_position = _screen_center + Vector2(x * 60 - 30, -y * 60 + 30)
+			#child.global_position = _screen_center + Vector2(p.x * 60 - 30, -p.y * 60 + 30)
+			child.global_position = _screen_center\
+									+ Vector2(60 * (p.x - 2) - 30, 30 - 60 * (3 - p.y))
 	add_child(child)
 
 func _input(event: InputEvent) -> void:

--- a/common/sliding_puzzle/tiles/base_tile.gd
+++ b/common/sliding_puzzle/tiles/base_tile.gd
@@ -10,7 +10,7 @@ var _moveable: bool = false
 var queries: Dictionary[String, Array] 
 # string one of [up, down, left, right], array of the form [PhysicsShapeQueryParameters2D, Vector2]
 var cursor: HandCursor
-enum AxisType {X, Y, M}
+enum AxisType {X = 1, Y, M}
 var axis: AxisType
 
 

--- a/common/sliding_puzzle/tiles/horizontal_tile/horizontal_tile.gd
+++ b/common/sliding_puzzle/tiles/horizontal_tile/horizontal_tile.gd
@@ -10,7 +10,7 @@ func _init() -> void:
 		"left": [PhysicsShapeQueryParameters2D.new(), Vector2(-60, 0)],
 		"right": [PhysicsShapeQueryParameters2D.new(), Vector2(60, 0)],
 	}
-	axis = AxisType.Y
+	axis = AxisType.X
 
 func _ready() -> void:
 	$Sprite2D.scale = Vector2(0.9375, 0.9375)

--- a/common/sliding_puzzle/tiles/vertical_tile/vertical_tile.gd
+++ b/common/sliding_puzzle/tiles/vertical_tile/vertical_tile.gd
@@ -10,7 +10,7 @@ func _init() -> void:
 		"up": [PhysicsShapeQueryParameters2D.new(), Vector2(0, -60)],
 		"down": [PhysicsShapeQueryParameters2D.new(), Vector2(0, 60)],
 	}
-	axis = AxisType.X
+	axis = AxisType.Y
 
 func _ready() -> void:
 	$Sprite2D.scale = Vector2(0.9375, 0.9375)

--- a/common/util/sliding_puzzle_generator.gd
+++ b/common/util/sliding_puzzle_generator.gd
@@ -1,0 +1,145 @@
+extends RefCounted
+class_name SlidingPuzzleGenerator
+
+
+const GRID_SIZE = 6
+const EXIT_POS = Vector2i(5, 3)
+const AXIS = BaseTile.AxisType
+
+class _Tile:
+	var axis: AXIS
+	var start: Vector2i
+	
+	func _init(p_axis: AXIS, p_start: Vector2i = Vector2i.ZERO) -> void:
+		self.axis = p_axis
+		self.start = p_start
+	
+	func _to_string() -> String:
+		return "Tile({0}, {1})".format([self.axis, self.start])
+	
+	static func _get_coords(tile: _Tile) -> Array[Vector2i]:
+		match tile.axis:
+			AXIS.X:
+				return [tile.start, tile.start + Vector2i.RIGHT]
+			AXIS.Y:
+				return [tile.start, tile.start + Vector2i.DOWN]
+			AXIS.M:
+				return [tile.start]
+			_:
+				return []
+	
+	static func _get_scramble_moves(tile: _Tile) -> Array[Vector2i]:
+		match tile.axis:
+			AXIS.X:
+				return [Vector2i.LEFT, Vector2i.RIGHT]
+			AXIS.Y:
+				return [Vector2i.UP, Vector2i.DOWN]
+			AXIS.M:
+				return [Vector2i.LEFT, Vector2i.UP, Vector2i.DOWN]
+			_:
+				return []
+
+
+static func generate_tiles():
+	var grid := _create_empty_grid() # Array[Array[int]]
+	#_print_grid(grid)
+	if grid.is_empty(): return null
+	
+	var sec_tiles: Array[_Tile] = []
+	var moves: Array[Vector2i]
+	
+	# Place main tile at exit
+	var main_tile = _Tile.new(AXIS.M, EXIT_POS)
+	_set_tile(grid, main_tile)
+	
+	# Add some secondary tiles at random positions
+	var n = randi_range(4, 6)
+	for i in range(n):
+		for orientation in [AXIS.X, AXIS.Y]:
+			for attempt in range(20):
+				var tile = _Tile.new(
+					orientation,
+					Vector2i(randi() % GRID_SIZE, randi() % GRID_SIZE)
+				)
+				#print(pos)
+				
+				if _is_tile_valid(grid, tile):
+					_set_tile(grid, tile)
+					sec_tiles.append(tile)
+					break
+	#print(sec_tiles)
+	#_print_grid(grid)
+	
+	# Scramble secondary tiles
+	for attempt in range(20):
+		var tile_to_move = sec_tiles.pick_random()
+		assert(tile_to_move != null, "ERROR: No secondary tiles generated")
+		#if tile_to_move == null:
+			#push_error("ERROR: No secondary tiles generated")
+			#return
+		
+		_scramble_tile_if_possible(grid, tile_to_move)
+		_scramble_tile_if_possible(grid, main_tile)
+		#print(main_tile)
+	
+	# Create result
+	var tile_locs = {
+		AXIS.X: [],
+		AXIS.Y: [],
+		AXIS.M: [main_tile.start],
+	}
+	for tile in sec_tiles:
+		tile_locs[tile.axis].append(tile.start)
+	#_print_grid(grid)
+	return tile_locs
+	
+static func _create_empty_grid() -> Array[PackedByteArray]:
+	var grid: Array[PackedByteArray] = []
+	if grid.resize(GRID_SIZE) != OK:
+		print("ERROR: in creating grid")
+	for i in range(GRID_SIZE):
+		grid[i] = PackedByteArray()
+		if grid[i].resize(GRID_SIZE) != OK:
+			print("ERROR: in creating grid")
+			return []
+	return grid
+
+static func _is_tile_valid(grid: Array[PackedByteArray], tile: _Tile) -> bool:
+	var positions = _Tile._get_coords(tile)
+	assert(positions, "ERROR: Unexpected tile axis when positioning")
+	for pos in positions:
+		if pos.x < 0 or pos.x >= GRID_SIZE or pos.y < 0 or pos.y >= GRID_SIZE or grid[pos.y][pos.x] != 0:
+			return false
+	return true
+
+static func _is_move_valid(grid: Array[PackedByteArray], tile: _Tile, offset: Vector2i) -> bool:
+	_set_tile(grid, tile, true)
+	tile.start += offset
+	var valid = _is_tile_valid(grid, tile)
+	tile.start -= offset
+	_set_tile(grid, tile)
+	return valid
+
+static func _scramble_tile_if_possible(grid: Array[PackedByteArray], tile: _Tile) -> void:#, offset: Vector2i):
+	var moves: Array[Vector2i] = _Tile._get_scramble_moves(tile)
+	assert(moves, "ERROR: Unexpected tile axis when scrambling")
+	var valid_moves: Array[Vector2i] = moves.filter(
+		func(move): return _is_move_valid(grid, tile, move)
+	)
+	
+	if not valid_moves.is_empty():
+		_set_tile(grid, tile, true)
+		tile.start += valid_moves.pick_random()
+		_set_tile(grid, tile)
+
+static func _set_tile(grid: Array[PackedByteArray], tile: _Tile, remove: bool = false) -> void:
+	var positions = _Tile._get_coords(tile)
+	var x = remove as int
+	assert(positions, "ERROR: Unexpected tile axis when positioning")
+	var value = 0 if remove else tile.axis
+	for pos in positions:
+		grid[pos.y][pos.x] = value
+#
+#static func _print_grid(grid: Array[PackedByteArray]) -> void:
+	#for row in grid:
+		#print(row)

--- a/common/util/sliding_puzzle_generator.gd.uid
+++ b/common/util/sliding_puzzle_generator.gd.uid
@@ -1,0 +1,1 @@
+uid://tsanx0q37qhv

--- a/levels/level_2/level_2.gd
+++ b/levels/level_2/level_2.gd
@@ -25,11 +25,12 @@ func _ready() -> void:
 	VisionManager.init_vision_for_level()
 
 func _on_puzzle_started() -> void:
-	$Stand1.puzzle.tile_location = {
-		"v2" : [[-2, -2], [-2, 0], [-2, 2], [-1, 0], [-1 ,2], [1, -1], [3, -1]],
-		"h2" : [[0, 1], [0, 2], [0, 3], [2, 1], [-1, -1], [-1, -2], [1, -2]],
-		"m" : [[0, 0]]
-	}
+	#$Stand1.puzzle.tile_location = {
+		#"h2" : [[0, 1], [0, 2], [0, 3], [2, 1], [-1, -1], [-1, -2], [1, -2]],
+		#"v2" : [[-2, -1], [-2, 1], [-2, 3], [-1, 1], [-1 ,3], [1, 0], [3, 0]],
+		#"m" : [[0, 0]]
+	#}
+	$Stand1.puzzle.tile_location = SlidingPuzzleGenerator.generate_tiles()
 	$Stand1.puzzle.offset = $Stand1.global_position
 
 func _on_puzzle_solved(stand: int) -> void:

--- a/levels/level_3/level_3.gd
+++ b/levels/level_3/level_3.gd
@@ -25,11 +25,12 @@ func _ready() -> void:
 	VisionManager.init_vision_for_level()
 
 func _on_puzzle_started() -> void:
-	$Stand1.puzzle.tile_location = {
-		"v2" : [[-2, -2], [-2, 0], [0, 0], [1 ,-2], [2, -2], [2, 2]],
-		"h2" : [[-2, 3], [-2, 2], [-1, -2], [-1, -1], [0, 2], [0, 3], [1, 1]],
-		"m" : [[-1, 1]]
-	}
+	#$Stand1.puzzle.tile_location = {
+		#"h2" : [[-2, 3], [-2, 2], [-1, -2], [-1, -1], [0, 2], [0, 3], [1, 1]],
+		#"v2" : [[-2, -1], [-2, 1], [0, 1], [1 ,-1], [2, -1], [2, 3]],
+		#"m" : [[-1, 1]]
+	#}
+	$Stand1.puzzle.tile_location = SlidingPuzzleGenerator.generate_tiles()
 	$Stand1.puzzle.offset = $Stand1.global_position
 
 func _on_puzzle_solved(stand: int) -> void:

--- a/levels/level_5/level_5.gd
+++ b/levels/level_5/level_5.gd
@@ -29,11 +29,12 @@ func _ready() -> void:
 func _on_puzzle_started(stand: int) -> void:
 	if stand == 2:
 		var stand_node = get_node("Stand%d" % stand)
-		stand_node.puzzle.tile_location = {
-			"v2" : [[-2, -2], [-1, -1], [0, 2], [1, 0], [2, -1], [3, 2]],
-			"h2" : [[-2, 3], [-1, -2], [0, -1], [1, 2], [2, -2], [2, 1]],
-			"m" : [[0, 0]]
-		}
+		#stand_node.puzzle.tile_location = {
+			#"h2" : [[-2, 3], [-1, -2], [0, -1], [1, 2], [2, -2], [2, 1]],
+			#"v2" : [[-2, -1], [-1, 0], [0, 3], [1, 1], [2, 0], [3, 3]],
+			#"m" : [[0, 0]]
+		#}
+		stand_node.puzzle.tile_location = SlidingPuzzleGenerator.generate_tiles()
 		stand_node.puzzle.offset = stand_node.global_position
 
 func _on_puzzle_solved(stand: int) -> void:


### PR DESCRIPTION
For the sliding block game, while the locations of the tiles can be modified as per the intended difficulty of each level, they have to be manually created and checked.

We introduce functionality to generate a random configuration of tiles for each instance of the game. However, as a draft, it only reverses a fixed number of moves from a completed state of the game and does not capture difficulty level. Hence, most game states are very easily solved.